### PR TITLE
add vendor.sh & fix go test invocation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,17 +16,7 @@ RUN go get -d ${LIBGIT2} && \
   git submodule update --init && \
   make install
 
-ENV PACKAGES github.com/codegangsta/cli \
-  golang.org/x/sys/unix \
-  github.com/vishvananda/netlink \
-  github.com/Sirupsen/logrus \
-  github.com/docker/docker/pkg/iptables \
-  github.com/docker/libpack \
-  github.com/docker/libcontainer \
-  github.com/erikh/ping \
-  github.com/syndtr/gocapability/capability
-
-RUN for i in ${PACKAGES}; do go get -v -d "$i"; done
+ENV GOPATH ${PKG}/vendor:${GOPATH}
 
 VOLUME ${PKG}
 WORKDIR ${PKG}

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ build: dockerbuild
 	$(RUN_CMD) go build -v
 
 test: dockerbuild
-	$(RUN_CMD) go test -v ./...
+	$(RUN_CMD) go test -v ${PKG}/drivers/simplebridge ${PKG}/namespace
 
 dockerbuild:
 	docker build -t $(IMGNAME) .	


### PR DESCRIPTION
This PR adds a vendor.sh script for vendoring and fixes invocation of go test in the Makefile

paired on this with @erikh